### PR TITLE
Correct task name for i2b22010re task in eval

### DIFF
--- a/biolm/utils_classification.py
+++ b/biolm/utils_classification.py
@@ -843,7 +843,7 @@ def compute_metrics(task_name, preds, labels, examples):
         return acc_p_r_and_f1(preds, labels)
     elif task_name == 'ddi':
         return ddi_eval(preds, labels)
-    elif task_name == "i2b22010":
+    elif task_name == "i2b22010re":
         return i2b22010re_eval(preds, labels)
     else:
         raise KeyError(task_name)


### PR DESCRIPTION
The task name for i2b2 2010 classification (RE) task was incomplete in the final evaluation section. I have corrected that.